### PR TITLE
feat: add github deploy key

### DIFF
--- a/terraform/live/github/kube-starter-kit/main.tf
+++ b/terraform/live/github/kube-starter-kit/main.tf
@@ -15,19 +15,18 @@ terraform {
 }
 
 provider "github" {
-  # Configuration options
   owner = "DevOps-Directive"
 }
 
-# Generate an ssh key using provider "hashicorp/tls"
 resource "tls_private_key" "deploy_key" {
   algorithm = "ED25519"
 }
 
-# Add the ssh key as a deploy key
-resource "github_repository_deploy_key" "example_repository_deploy_key" {
-  title      = "Repository test key"
-  repository = "kube-starter-kit"
-  key        = tls_private_key.deploy_key.public_key_openssh
-  read_only  = true
-}
+# TODO: This can't be deployed with standard github action token permissions...
+#       Need to figure out a way to automate (PAT or octo-sts)
+# resource "github_repository_deploy_key" "example_repository_deploy_key" {
+#   title      = "Repository test key"
+#   repository = "kube-starter-kit"
+#   key        = tls_private_key.deploy_key.public_key_openssh
+#   read_only  = true
+# }


### PR DESCRIPTION
I think this would only be possible with a PAT or something like https://github.com/apps/octo-sts (it looks like octo-sts doesn't have repo: admin permissions out of the box). 

```
Error: POST https://api.github.com/repos/DevOps-Directive/kube-starter-kit/keys: 403 Resource not accessible by integration []
  with github_repository_deploy_key.example_repository_deploy_key,
  on main.tf line 28, in resource "github_repository_deploy_key" "example_repository_deploy_key":
  28: resource "github_repository_deploy_key" "example_repository_deploy_key" {
```

The "for now" solution (until I decide if it is worth automating fully) may be to automate:
1. create key in eks root module(s)
2. output public key
3. create aws secret containing private key
4. document manual step to add public key to github

