### PR TITLE
fix: validate and update karpenter tagging config

### DIFF
--- a/kubernetes/initial-setup-validation/karpenter/Taskfile.yaml
+++ b/kubernetes/initial-setup-validation/karpenter/Taskfile.yaml
@@ -11,3 +11,7 @@ tasks:
           --version 1.7.1 \
           --namespace kube-system \
           --values values.yaml
+
+  apply-resources:
+    cmds:
+      - kubectl apply -f ./resources

--- a/kubernetes/initial-setup-validation/karpenter/resources/Deployment.inflate.yaml
+++ b/kubernetes/initial-setup-validation/karpenter/resources/Deployment.inflate.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: inflate
+spec:
+  # To scale up:
+  # k scale deployment inflate --replicas=5
+  replicas: 0
+  selector:
+    matchLabels:
+      app: inflate
+  template:
+    metadata:
+      labels:
+        app: inflate
+    spec:
+      terminationGracePeriodSeconds: 0
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 3000
+        fsGroup: 2000
+      containers:
+        - name: inflate
+          image: public.ecr.aws/eks-distro/kubernetes/pause:3.7
+          resources:
+            requests:
+              cpu: 1
+          securityContext:
+            allowPrivilegeEscalation: false

--- a/kubernetes/initial-setup-validation/karpenter/resources/EC2NodeClass.default.yaml
+++ b/kubernetes/initial-setup-validation/karpenter/resources/EC2NodeClass.default.yaml
@@ -1,0 +1,18 @@
+apiVersion: karpenter.k8s.aws/v1
+kind: EC2NodeClass
+metadata:
+  name: default
+spec:
+  role: "KarpenterNodeRole-staging-us-east-2"
+  amiSelectorTerms:
+    # https://karpenter.sh/docs/getting-started/getting-started-with-karpenter/#2-set-environment-variables
+    # aws ssm get-parameter --name "/aws/service/eks/optimized-ami/1.33/amazon-linux-2023/x86_64/standard/recommended/image_id" --query Parameter.Value | xargs aws ec2 describe-images --query 'Images[0].Name' --image-ids | sed -r 's/^.*(v[[:digit:]]+).*$/\1/'
+    - alias: "al2023@v20250920"
+  subnetSelectorTerms:
+    - tags:
+        # Created by VPC TF module
+        karpenter.sh/discovery: "staging-us-east-2"
+  securityGroupSelectorTerms:
+    - tags:
+        # Created by EKS TF module
+        karpenter.sh/discovery: "staging-us-east-2"

--- a/kubernetes/initial-setup-validation/karpenter/resources/NodePool.default.yaml
+++ b/kubernetes/initial-setup-validation/karpenter/resources/NodePool.default.yaml
@@ -1,0 +1,33 @@
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: default
+spec:
+  template:
+    spec:
+      requirements:
+        - key: kubernetes.io/arch
+          operator: In
+          values: ["amd64"]
+        - key: kubernetes.io/os
+          operator: In
+          values: ["linux"]
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["on-demand"]
+        - key: karpenter.k8s.aws/instance-category
+          operator: In
+          values: ["c", "m", "r"]
+        - key: karpenter.k8s.aws/instance-generation
+          operator: Gt
+          values: ["2"]
+      nodeClassRef:
+        group: karpenter.k8s.aws
+        kind: EC2NodeClass
+        name: default
+      expireAfter: 720h # 30 * 24h = 720h
+  limits:
+    cpu: 1000
+  disruption:
+    consolidationPolicy: WhenEmptyOrUnderutilized
+    consolidateAfter: 1m

--- a/terraform/live/aws/staging/us-east-2/eks/karpenter-resources.tf
+++ b/terraform/live/aws/staging/us-east-2/eks/karpenter-resources.tf
@@ -10,7 +10,7 @@ module "karpenter" {
 
   # Name needs to match role name passed to the EC2NodeClass
   node_iam_role_use_name_prefix   = false
-  node_iam_role_name              = local.name
+  node_iam_role_name              = "KarpenterNodeRole-${local.name}"
   create_pod_identity_association = true
 
   # Used to attach additional IAM policies to the Karpenter node IAM role

--- a/terraform/live/aws/staging/us-east-2/eks/main.tf
+++ b/terraform/live/aws/staging/us-east-2/eks/main.tf
@@ -106,5 +106,4 @@ module "eks" {
   node_security_group_tags = {
     "karpenter.sh/discovery" = local.name
   }
-
 }

--- a/terraform/live/aws/staging/us-east-2/networking/main.tf
+++ b/terraform/live/aws/staging/us-east-2/networking/main.tf
@@ -17,8 +17,8 @@ terraform {
 data "aws_availability_zones" "available" {}
 
 locals {
-  name   = "infrastructure"
-  region = "us-west-2"
+  name   = "staging"
+  region = "us-east-2"
 
   # TODO: design private network CIDRs to split across VPCs
   vpc_cidr = "10.0.0.0/16"
@@ -38,7 +38,7 @@ module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "6.4.0"
 
-  name = local.name
+  name = "${local.name}-${local.region}"
   cidr = local.vpc_cidr
 
   azs             = local.azs
@@ -46,6 +46,11 @@ module "vpc" {
   public_subnets  = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 8, k + 4)]
 
   enable_nat_gateway = false # use https://fck-nat.dev/ instead
+
+  private_subnet_tags = {
+    "karpenter.sh/discovery" = "${local.name}-${local.region}"
+
+  }
 }
 
 module "fck-nat" {

--- a/tools/aws/.kube-starter-kit-rc
+++ b/tools/aws/.kube-starter-kit-rc
@@ -16,6 +16,7 @@ unset-env-vars () {
   unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
 }
 
+aws-sso-infrastructure () { aws-sso-login infrastructure; }
 aws-sso-staging () { aws-sso-login staging; }
 aws-sso-production () { aws-sso-login production; }
 

--- a/tools/aws/README.md
+++ b/tools/aws/README.md
@@ -1,0 +1,11 @@
+Copy AWS config (after modifying account IDs) to:
+```
+~/.aws/config
+```
+
+Add to ~/.zshrc or ~/.bashrc:
+```
+# kube-starter-kit
+. ~/path/to/kube-starter-kit/tools/aws/.kube-starter-kit-rc
+# kube-starter-kit end
+```

--- a/tools/aws/config
+++ b/tools/aws/config
@@ -1,0 +1,24 @@
+[default]
+
+[profile infrastructure]
+region = us-east-2
+sso_session = primary
+sso_account_id = 094905625236
+sso_role_name = AWSAdministratorAccess
+
+[profile staging]
+region = us-east-2
+sso_session = primary
+sso_account_id = 038198578795
+sso_role_name = AWSAdministratorAccess
+
+[profile production]
+region = us-east-2
+sso_session = primary
+sso_account_id = 964263445142
+sso_role_name = AWSAdministratorAccess
+
+[sso-session primary]
+sso_start_url = https://d-9a676f52a0.awsapps.com/start/#
+sso_region = us-east-2
+sso_registration_scopes = sso:account:access


### PR DESCRIPTION
Added tagging for subnets and security groups to use by karpenter nodepool selectors